### PR TITLE
Updates to processResult

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/gorilla/websocket v0.0.0-20160217174351-4935ba31a2ad
 	github.com/kr/pretty v0.1.0 // indirect
+	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852 // indirect
 	golang.org/x/net v0.0.0-20190403144856-b630fd6fe46b // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/xmlpath.v2 v2.0.0-20150820204837-860cbeca3ebc

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852 h1:Yl0tPBa8QPjGmesFh1D0rDy+q1Twx6FyU7VWHi8wZbI=
+github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852/go.mod h1:eqOVx5Vwu4gd2mmMZvVZsgIqNSaW3xxRThUJ0k/TPk4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190403144856-b630fd6fe46b h1:/zjbcJPEGAyu6Is/VBOALsgdi4z9+kz/Vtdm6S+beD0=
 golang.org/x/net v0.0.0-20190403144856-b630fd6fe46b/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/internal/pkg/action/httpreq.go
+++ b/internal/pkg/action/httpreq.go
@@ -24,10 +24,15 @@ SOFTWARE.
 package action
 
 import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -35,12 +40,8 @@ import (
 	"github.com/eriklupander/gotling/internal/pkg/runtime"
 	"github.com/eriklupander/gotling/internal/pkg/testdef"
 	"github.com/eriklupander/gotling/internal/pkg/util"
-
-	//"fmt"
+	"github.com/oliveagle/jsonpath"
 	"gopkg.in/xmlpath.v2"
-	//"github.com/NodePrime/jsonpath"
-	"bytes"
-	"crypto/tls"
 )
 
 // Accepts a Httpaction and a one-way channel to write the results to.
@@ -143,33 +144,36 @@ func buildHttpRequest(httpAction HttpAction, sessionMap map[string]string) *http
  * TODO extract both Jsonpath handling and Xmlpath handling into separate functions, and write tests for them.
  */
 func processResult(httpAction HttpAction, sessionMap map[string]string, responseBody []byte) {
-	//if httpAction.ResponseHandler.Jsonpath != "" {
-	//    paths, err := jsonpath.ParsePaths(httpAction.ResponseHandler.Jsonpath)
-	//    if err != nil {
-	//        panic(err)
-	//    }
-	//    eval, err := jsonpath.EvalPathsInBytes(responseBody, paths)
-	//    if err != nil {
-	//        panic(err)
-	//    }
-	//
-	//    // TODO optimization: Don't reinitialize each time, reuse this somehow.
-	//    resultsArray := make([]string, 0, 10)
-	//    for {
-	//        if result, ok := eval.Next(); ok {
-	//
-	//            value := strings.TrimSpace(result.Pretty(false))
-	//            resultsArray = append(resultsArray, trimChar(value, '"'))
-	//        } else {
-	//            break
-	//        }
-	//    }
-	//    if eval.Error != nil {
-	//        panic(eval.Error)
-	//    }
-	//
-	//    passResultIntoSessionMap(resultsArray, httpAction, sessionMap)
-	//}
+	if httpAction.ResponseHandler.Jsonpath != "" {
+		jsonPattern, err := jsonpath.Compile(httpAction.ResponseHandler.Jsonpath)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		var jsonData interface{}
+		json.Unmarshal(responseBody, &jsonData)
+
+		res, err := jsonPattern.Lookup(jsonData)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		var resultArray []string
+		v := reflect.ValueOf(res)
+		switch v.Kind() {
+		case reflect.String:
+			resultArray = []string{res.(string)}
+		case reflect.Slice:
+			a := res.([]interface{})
+			resultArray = make([]string, len(a))
+			for idx, val := range a {
+				resultArray[idx] = fmt.Sprintf("%s", val)
+			}
+		default:
+			log.Printf("Unknown type [%T]", reflect.TypeOf(res))
+		}
+		passResultIntoSessionMap(resultArray, httpAction, sessionMap)
+	}
 
 	if httpAction.ResponseHandler.Xmlpath != "" {
 		path := xmlpath.MustCompile(httpAction.ResponseHandler.Xmlpath)


### PR DESCRIPTION
This PR fixes:

* `testdef.RANDOM` in `passResultIntoSessionMap()` didn't have a random seed and would always pick the same item. It now uses the UnixNano to seed the randomizer

This PR adds:

* the JSONPath handling in `processResult()` is added back based on `github.com/oliveagle/jsonpath`