### PR TITLE
Feature: HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ Define your test setup in a .yml file
             address: 127.0.0.1:8081                     # TCP socket connection
             payload: |TYPE|1|${UID}|${email}            # Sample data using parameter substitution
 
+### HTTP headers
+Gotling supports adding HTTP headers in the YAML specification:
+
+    - http:
+        title: Some title
+        method: POST
+        headers:
+            foo: bar
+            hello: world
+        url: http://localhost:9183/mypath
+        body: '{"id":100,"name":"Some name","author":"${author}-${someId}","created":"2015-10-23T21:33:38.254+02:00","baseLatitude":45.634353,"baseLongitude":11.3424324}'
+        accept: application/json
+
+To give this a try, create a [RequestBin URL](http://requestbin.net/) will collect requests made to it and let you inspect them in a human-friendly way and paste that URL in the [demoheaders.yml](./samples/demoheaders.yml) on line 9.
+
 ### HTTP POST bodies
 Gotling supports POST/PUT bodies either directly inlined in the YAML specification, or read from a template file:
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/gorilla/websocket v0.0.0-20160217174351-4935ba31a2ad
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852 // indirect
+	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852
 	golang.org/x/net v0.0.0-20190403144856-b630fd6fe46b // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/xmlpath.v2 v2.0.0-20150820204837-860cbeca3ebc

--- a/internal/pkg/action/actionbuilder.go
+++ b/internal/pkg/action/actionbuilder.go
@@ -24,10 +24,11 @@ SOFTWARE.
 package action
 
 import (
-	"github.com/eriklupander/gotling/internal/pkg/testdef"
 	"io/ioutil"
 	"log"
 	"os"
+
+	"github.com/eriklupander/gotling/internal/pkg/testdef"
 )
 
 func BuildActionList(t *testdef.TestDef) ([]Action, bool) {
@@ -80,4 +81,15 @@ func getTemplate(action map[interface{}]interface{}) string {
 	} else {
 		return ""
 	}
+}
+
+func getHeaders(action map[interface{}]interface{}) map[string]string {
+	headers := make(map[string]string)
+	if action["headers"] != nil {
+		hm := action["headers"].(map[interface{}]interface{})
+		for key, value := range hm {
+			headers[key.(string)] = value.(string)
+		}
+	}
+	return headers
 }

--- a/internal/pkg/action/httpaction.go
+++ b/internal/pkg/action/httpaction.go
@@ -24,8 +24,9 @@ SOFTWARE.
 package action
 
 import (
-	"github.com/eriklupander/gotling/internal/pkg/result"
 	"log"
+
+	"github.com/eriklupander/gotling/internal/pkg/result"
 )
 
 type HttpAction struct {
@@ -38,6 +39,7 @@ type HttpAction struct {
 	Title           string              `yaml:"title"`
 	ResponseHandler HttpResponseHandler `yaml:"response"`
 	StoreCookie     string              `yaml:"storeCookie"`
+	Headers         map[string]string   `yaml:"headers"`
 }
 
 func (h HttpAction) Execute(resultsChannel chan result.HttpReqResult, sessionMap map[string]string) {
@@ -137,6 +139,7 @@ func NewHttpAction(a map[interface{}]interface{}) HttpAction {
 		a["title"].(string),
 		responseHandler,
 		storeCookie,
+		getHeaders(a),
 	}
 
 	return httpAction

--- a/internal/pkg/action/httpreq.go
+++ b/internal/pkg/action/httpreq.go
@@ -125,6 +125,14 @@ func buildHttpRequest(httpAction HttpAction, sessionMap map[string]string) *http
 		req.Header.Add(key, value)
 	}
 
+	if hostHeader, found := httpAction.Headers["host"]; found {
+		req.Host = hostHeader
+	}
+
+	if hostHeader, found := httpAction.Headers["Host"]; found {
+		req.Host = hostHeader
+	}
+
 	// Add cookies stored by subsequent requests in the sessionMap having the kludgy ____ prefix
 	for key, value := range sessionMap {
 		if strings.HasPrefix(key, "____") {

--- a/internal/pkg/action/httpreq.go
+++ b/internal/pkg/action/httpreq.go
@@ -121,12 +121,16 @@ func buildHttpRequest(httpAction HttpAction, sessionMap map[string]string) *http
 		req.Header.Add("Content-Type", httpAction.ContentType)
 	}
 
+	for key, value := range httpAction.Headers {
+		req.Header.Add(key, value)
+	}
+
 	// Add cookies stored by subsequent requests in the sessionMap having the kludgy ____ prefix
 	for key, value := range sessionMap {
 		if strings.HasPrefix(key, "____") {
 
 			cookie := http.Cookie{
-				Name:  key[4:len(key)],
+				Name:  key[4:],
 				Value: value,
 			}
 

--- a/samples/demoheaders.yml
+++ b/samples/demoheaders.yml
@@ -4,7 +4,7 @@ users: 2
 rampup: 3
 actions:
   - http:
-      title: Read google.com
+      title: Post to RequestBin
       method: POST
       url: http://requestbin.net/r/189w13m1
       headers:

--- a/samples/demoheaders.yml
+++ b/samples/demoheaders.yml
@@ -1,0 +1,15 @@
+---
+iterations: 3
+users: 2
+rampup: 3
+actions:
+  - http:
+      title: Read google.com
+      method: POST
+      url: http://requestbin.net/r/189w13m1
+      headers:
+        hello: world
+        foo: bar
+      accept: json
+  - sleep:
+      duration: 3


### PR DESCRIPTION
To test my ingress gateways on Kubernetes, I needed to add support for HTTP headers. I wanted to contribute that back as likely others might need it too.

The headers are a `map[string]string` read from the configuration yml file.
