### PR TITLE
Fix UDP Action Panic

### DIFF
--- a/internal/pkg/action/udpaction.go
+++ b/internal/pkg/action/udpaction.go
@@ -23,7 +23,9 @@ SOFTWARE.
 */
 package action
 
-import "github.com/eriklupander/gotling/internal/pkg/result"
+import (
+	"github.com/eriklupander/gotling/internal/pkg/result"
+)
 
 type UdpAction struct {
 	Address string `yaml:"address"`
@@ -36,12 +38,22 @@ func (t UdpAction) Execute(resultsChannel chan result.HttpReqResult, sessionMap 
 }
 
 func NewUdpAction(a map[interface{}]interface{}) UdpAction {
-
-	// TODO validation
+	payload, ok := a["payload"].(string)
+	if !ok {
+		return UdpAction{}
+	}
+	address, ok := a["address"].(string)
+	if !ok {
+		return UdpAction{}
+	}
+	title, ok := a["title"].(string)
+	if !ok {
+		return UdpAction{}
+	}
 	return UdpAction{
-		a["address"].(string),
-		a["payload"].(string),
-		a["title"].(string),
+		address,
+		payload,
+		title,
 	}
 }
 


### PR DESCRIPTION
Using Go 1.15 I getting the following problem trying to run a udp action, and this PR fixes it.

```
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/eriklupander/gotling/internal/pkg/action.NewUdpAction(0xc000097650, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/media/solidity/DATA/Code/bonedaddy/gotling/internal/pkg/action/udpaction.go:53 +0x3bf
github.com/eriklupander/gotling/internal/pkg/action.BuildActionList(0xc00008d590, 0x1, 0x270, 0x796ea0, 0xc00008d590)
	/media/solidity/DATA/Code/bonedaddy/gotling/internal/pkg/action/actionbuilder.go:51 +0x312
main.main()
	/media/solidity/DATA/Code/bonedaddy/gotling/cmd/gotling/main.go:67 +0x1d7
```